### PR TITLE
ci: use GitHub App token for auto-merge workflow

### DIFF
--- a/.github/workflows/enable_pr_automerge.yaml
+++ b/.github/workflows/enable_pr_automerge.yaml
@@ -9,8 +9,16 @@ jobs:
   enable_automerge:
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Enable auto-merge for PRs
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.PR_GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: '${{ steps.get_token.outputs.token }}'


### PR DESCRIPTION
## Summary
- Replace expired `PR_GITHUB_TOKEN` PAT with `actions/create-github-app-token@v3`
- Aligns with auto-merge workflow used by other opzkit modules
- Fixes 401 Bad credentials in [run 24833208935](https://github.com/opzkit/database-user-operator/actions/runs/24833208935)

## Prereqs
- `vars.AUTO_MERGE_APP_ID` and `secrets.AUTO_MERGE_PRIVATE_KEY` must be available (org-level)
- GitHub App must be installed on this repo with PR + contents write

## Test plan
- [ ] Auto-merge job succeeds on this PR
- [ ] Delete unused `PR_GITHUB_TOKEN` secret after merge