### PR TITLE
fix(ci): pin setup-envtest to Go 1.25-compatible release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ GOLANGCI_LINT_VERSION ?= v1.62.2
 KUBECTL_VERSION ?= v1.28.0
 KIND_VERSION ?= v0.20.0
 HELM_VERSION ?= v3.13.0
+ENVTEST_VERSION ?= release-0.23
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -256,7 +257,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.


### PR DESCRIPTION
## Summary
- `Makefile` pulled `setup-envtest@latest`, which floated to v0.24.0 requiring Go 1.26.0
- Runner Go is 1.25.0 (from `go.mod`) → install fails: `requires go >= 1.26.0`
- Pin to `release-0.23` branch matching `sigs.k8s.io/controller-runtime v0.23.1` already in `go.mod`
- Unblocks unit + integration test jobs (broken on PRs #136 and #137)

## Test plan
- [ ] `make test` succeeds in CI
- [ ] Integration test job green
- [ ] Renovate picks up future bumps via `ENVTEST_VERSION` constant