### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @argoyle @peter-svensson


### PR DESCRIPTION
## Summary
- Add root `CODEOWNERS` matching sibling opzkit modules (godeadcode-action, terraform-aws-k8s-addons-*, etc.)
- Default reviewers for all paths: @argoyle @peter-svensson

## Test plan
- [ ] GitHub recognizes the file (PR shows requested reviewers automatically on next PR)