### PR TITLE
ci: bump golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.6.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,9 +27,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
-
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.12.2
+          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,8 @@ formatters:
     - goimports
   settings:
     goimports:
-      local-prefixes: opzkit/database-user-operator
+      local-prefixes:
+        - opzkit/database-user-operator
 
 linters:
   # Default linters are already enabled: errcheck, govet, ineffassign, staticcheck, unused


### PR DESCRIPTION
## Summary
- `lint.yaml` installs golangci-lint **v2.6.1** — built with Go 1.25, rejects code targeting Go 1.26
- Bumps to **v2.12.2** (built with Go 1.26)
- Unblocks Renovate PR #142 (toolchain bump to go1.26.2) and PR #94 (controller-runtime v0.24)

## Error fixed
```
can't load config: the Go language version (go1.25) used to build golangci-lint
is lower than the targeted Go version (1.26.2)
```

## Test plan
- [ ] Lint job passes on this PR
- [ ] After merge, PR #142 lint passes