### PR TITLE
feat: stamp version/gitCommit/buildDate into manager binary

### DIFF
--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -64,6 +64,10 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Compute build date
+        id: build_date
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         id: build
@@ -73,6 +77,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build_date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM golang:1.26-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d273950
 ARG TARGETOS
 ARG TARGETARCH
 ARG ENABLE_COVERAGE=false
+ARG VERSION=dev
+ARG GIT_COMMIT=none
+ARG BUILD_DATE=unknown
 
 WORKDIR /workspace
 
@@ -20,11 +23,12 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
-# Build with optional coverage instrumentation
-RUN if [ "$ENABLE_COVERAGE" = "true" ]; then \
-      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -cover -covermode=atomic -tags=cover -a -o manager ./cmd/manager; \
+# Build with optional coverage instrumentation. Build metadata stamped via -ldflags.
+RUN LDFLAGS="-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE}" && \
+    if [ "$ENABLE_COVERAGE" = "true" ]; then \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -cover -covermode=atomic -tags=cover -a -ldflags "$LDFLAGS" -o manager ./cmd/manager; \
     else \
-      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/manager; \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "$LDFLAGS" -o manager ./cmd/manager; \
     fi
 
 # Use distroless as minimal base image to package the manager binary

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,11 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// Build metadata, populated at link time via -ldflags "-X main.<var>=...".
+	version   = "dev"
+	gitCommit = "none"
+	buildDate = "unknown"
 )
 
 func init() {
@@ -43,6 +48,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("starting database-user-operator",
+		"version", version,
+		"gitCommit", gitCommit,
+		"buildDate", buildDate)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,


### PR DESCRIPTION
## Summary
- Adds package-level `version`, `gitCommit`, `buildDate` vars in `cmd/manager/main.go`, populated at link time via `-ldflags "-X main.<var>=..."`
- Logs them once at startup so triage can confirm which image is running (raised in #135 review while debugging the GRANT issue across two near-identical `pr-135` rebuilds)
- `Dockerfile` accepts `VERSION`, `GIT_COMMIT`, `BUILD_DATE` build args and threads them into both the regular and coverage builds
- `build-and-scan.yaml` passes `docker/metadata-action` `version`, `github.sha` and an ISO-8601 build date as docker build args

## Example log line
```
{"level":"info","msg":"starting database-user-operator","version":"pr-145","gitCommit":"8567361...","buildDate":"2026-05-07T11:40:00Z"}
```

## Test plan
- [x] `go build -ldflags "-X main.version=test ..." ./cmd/manager` succeeds and stamps the values
- [ ] CI builds the image and the version banner shows the PR-derived metadata
- [ ] Pull the resulting image and confirm `kubectl logs ...` shows the stamped values

## Follow-ups
- Could expose `/version` via the existing health-probe listener and a `--version` CLI flag if scrapeable build info is wanted — out of scope for this PR.