### PR TITLE
chore(renovate): group k8s.io and controller-runtime

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,17 @@
         "ghcr.io/opzkit/database-user-operator"
       ],
       "enabled": false
+    },
+    {
+      "description": "Group k8s.io/* and sigs.k8s.io/controller-runtime so they bump in lockstep (k8s 0.36 needs controller-runtime 0.24)",
+      "groupName": "kubernetes",
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "/^k8s\\.io//",
+        "sigs.k8s.io/controller-runtime"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRule` grouping `k8s.io/*` with `sigs.k8s.io/controller-runtime`
- Future bumps land in a single PR instead of an unmergeable intermediate state

## Why
PR #111 (k8s monorepo → v0.36) and PR #94 (controller-runtime → v0.24) hit each other:
- k8s 0.36 added `HasSyncedChecker` to `ResourceEventHandlerRegistration`
- controller-runtime 0.23.1's `handlerRegistration` doesn't implement it
- → `typecheck` lint failure on whichever PR is rebased first

Grouping forces them to ship together.

## Test plan
- [ ] Renovate dashboard shows a `kubernetes` group on next run
- [ ] After both #94 and #111 merge, next k8s bump arrives as a single grouped PR