### PR TITLE
fix: keep gomega in go.sum across renovate updates

### DIFF
--- a/test/integration/deps_test.go
+++ b/test/integration/deps_test.go
@@ -1,0 +1,15 @@
+// Copyright 2025 OpzKit
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+// Imported here (without the integration build tag) so `go mod tidy` keeps
+// ginkgo and gomega in go.sum. Real usages live in *_test.go files behind
+// //go:build integration.
+
+package integration
+
+import (
+	_ "github.com/onsi/ginkgo/v2"
+	_ "github.com/onsi/gomega"
+)


### PR DESCRIPTION
## Summary

Renovate-driven ginkgo and gomega bumps fail integration tests with
`missing go.sum entry for module providing package github.com/onsi/...`
(see PR #131, #132). Root cause: `test/integration/{integration,operator}_test.go`
import them behind `//go:build integration`, but `go mod tidy` ignores
files behind custom build tags, so it strips or omits them from `go.sum`
during the upgrade.

Fix: add a tag-free `deps_test.go` with blank imports of both `ginkgo/v2`
and `gomega` in the same package. Tidy now sees them from default builds
and keeps them tracked. No runtime impact — file builds alone (side-effect
imports only) without the tag, sits next to the real users with the tag.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, retry PR #131 (ginkgo v2.28.3) and PR #132 (gomega v1.40.0) — integration job
      should pass without manual `go.sum` editing