### PR TITLE
feat(scaleway): write secrets to Scaleway native path + name

### DIFF
--- a/internal/secrets/scaleway.go
+++ b/internal/secrets/scaleway.go
@@ -42,9 +42,20 @@ type ScalewaySMClient interface {
 
 // ScalewayBackend stores generated database credentials in Scaleway
 // Secret Manager. The DatabaseSecret JSON blob is stored verbatim as
-// the version payload on a Scaleway Secret named after a sanitised
-// version of the supplied name (slashes replaced with underscores so
-// the result is a valid Scaleway Secret name).
+// the version payload on a Scaleway Secret.
+//
+// The supplied `spec.secretName` is split on the last `/` into
+// (Path, Name): leading segments become the Scaleway Secret Path
+// (folder), the trailing segment is the Secret Name. This matches
+// the AWS Secrets Manager backend, where slashes stay in the literal
+// name — both backends therefore land at the same logical location
+// (default `rds/postgres/<dbName>`).
+//
+// For backwards compatibility with secrets previously written by
+// pre-path versions of this operator (slashes flattened to `_`),
+// findSecret falls back to a legacy sanitised-name lookup at root
+// path when the path-style lookup misses. New writes always use the
+// path-aware shape.
 //
 // Each Update creates a new SecretVersion; the returned version string
 // is the SecretVersion Revision (1-based monotonic).
@@ -106,36 +117,90 @@ func parseScalewayRegion(region string) (scw.Region, error) {
 	return r, nil
 }
 
-// scalewayName normalises an arbitrary "secret name" (which may include
-// slashes from the AWS-style rds/<engine>/<db> default) into a valid
-// Scaleway Secret name. Scaleway accepts [A-Za-z0-9-_.] in names.
-func scalewayName(name string) string {
+// scalewayPathAndName splits an arbitrary "secret name" (which may
+// include slashes from the AWS-style rds/<engine>/<db> default) into
+// the (Path, Name) pair Scaleway Secret Manager uses. The last
+// `/`-segment is the Name; everything before it (leading + trailing
+// `/` enforced) is the Path. Single-segment input lands at root
+// path `/`. Scaleway accepts [A-Za-z0-9-_.] in names and arbitrary
+// `/`-separated folder paths.
+//
+//	"rds/postgres/foo"   -> ("/rds/postgres/", "foo")
+//	"/rds/postgres/foo"  -> ("/rds/postgres/", "foo")
+//	"/rds/postgres/foo/" -> ("/rds/postgres/", "foo")
+//	"foo"                -> ("/",              "foo")
+//	""                   -> ("/",              "")
+func scalewayPathAndName(input string) (string, string) {
+	trimmed := strings.Trim(input, "/")
+	if trimmed == "" {
+		return "/", ""
+	}
+	idx := strings.LastIndex(trimmed, "/")
+	if idx < 0 {
+		return "/", trimmed
+	}
+	return "/" + trimmed[:idx] + "/", trimmed[idx+1:]
+}
+
+// scalewayLegacyName reproduces the pre-path sanitisation (slashes
+// flattened to underscores) used by older releases of this operator.
+// Retained for read-side fallback so existing Secrets remain findable
+// after upgrade.
+func scalewayLegacyName(name string) string {
 	n := strings.Trim(name, "/")
-	n = strings.ReplaceAll(n, "/", "_")
-	return n
+	return strings.ReplaceAll(n, "/", "_")
 }
 
 // locator returns a stable backend-specific identifier for the secret.
-// Uses (region, projectID, sanitised-name) so it stays human-readable
-// and is independent of the secret's UUID at lookup time.
+// Uses (region, projectID, path+name) so it stays human-readable and is
+// independent of the secret's UUID at lookup time.
 func (b *ScalewayBackend) locator(name string) string {
-	return fmt.Sprintf("scaleway://%s/%s/%s", b.region, b.projectID, scalewayName(name))
+	path, n := scalewayPathAndName(name)
+	return fmt.Sprintf("scaleway://%s/%s%s%s", b.region, b.projectID, path, n)
 }
 
-// findSecret looks up a Scaleway Secret by name+project. Returns
-// (*smapi.Secret, true, nil) on hit, (nil, false, nil) on miss.
+// findSecret looks up a Scaleway Secret by (Path, Name, project).
+// On a miss, falls back to a legacy sanitised-name lookup at root
+// path so secrets written by pre-path operator versions remain
+// readable. Returns (*smapi.Secret, true, nil) on hit,
+// (nil, false, nil) on miss.
 func (b *ScalewayBackend) findSecret(ctx context.Context, name string) (*smapi.Secret, bool, error) {
-	n := scalewayName(name)
+	path, n := scalewayPathAndName(name)
 	resp, err := b.client.ListSecrets(&smapi.ListSecretsRequest{
 		Region:    b.region,
 		ProjectID: &b.projectID,
 		Name:      &n,
+		Path:      &path,
 	}, scw.WithContext(ctx))
 	if err != nil {
 		return nil, false, fmt.Errorf("scaleway list-secrets failed: %w", err)
 	}
 	for _, s := range resp.Secrets {
-		if s.Name == n {
+		if s.Name == n && s.Path == path {
+			return s, true, nil
+		}
+	}
+
+	// Legacy fallback: pre-path releases wrote secrets at root path
+	// with `/` flattened to `_`. Only consult when the path-style
+	// lookup truly missed and the legacy form differs from the
+	// path-style name (i.e. the input contained at least one `/`).
+	legacy := scalewayLegacyName(name)
+	if legacy == n {
+		return nil, false, nil
+	}
+	rootPath := "/"
+	resp, err = b.client.ListSecrets(&smapi.ListSecretsRequest{
+		Region:    b.region,
+		ProjectID: &b.projectID,
+		Name:      &legacy,
+		Path:      &rootPath,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return nil, false, fmt.Errorf("scaleway list-secrets (legacy) failed: %w", err)
+	}
+	for _, s := range resp.Secrets {
+		if s.Name == legacy && (s.Path == rootPath || s.Path == "") {
 			return s, true, nil
 		}
 	}
@@ -206,10 +271,12 @@ func (b *ScalewayBackend) Create(ctx context.Context, name, description string, 
 			return "", "", fmt.Errorf("scaleway update-secret (description/tags) failed: %w", err)
 		}
 	} else {
+		path, n := scalewayPathAndName(name)
 		createReq := &smapi.CreateSecretRequest{
 			Region:    b.region,
 			ProjectID: b.projectID,
-			Name:      scalewayName(name),
+			Name:      n,
+			Path:      &path,
 			Tags:      tagsToScalewaySlice(tags),
 		}
 		if description != "" {

--- a/internal/secrets/scaleway_test.go
+++ b/internal/secrets/scaleway_test.go
@@ -59,6 +59,9 @@ func (f *fakeScalewayClient) ListSecrets(req *smapi.ListSecretsRequest, _ ...scw
 		if req.ProjectID != nil && s.ProjectID != *req.ProjectID {
 			continue
 		}
+		if req.Path != nil && s.Path != *req.Path {
+			continue
+		}
 		out.Secrets = append(out.Secrets, s)
 	}
 	out.TotalCount = uint64(len(out.Secrets))
@@ -76,10 +79,15 @@ func (f *fakeScalewayClient) CreateSecret(req *smapi.CreateSecretRequest, _ ...s
 	if req.Description != nil {
 		desc = *req.Description
 	}
+	path := "/"
+	if req.Path != nil {
+		path = *req.Path
+	}
 	s := &smapi.Secret{
 		ID:          id,
 		ProjectID:   req.ProjectID,
 		Name:        req.Name,
+		Path:        path,
 		Tags:        append([]string(nil), req.Tags...),
 		Description: &desc,
 		Region:      req.Region,
@@ -182,8 +190,13 @@ func TestScalewayBackend_Create_NewSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if loc != "scaleway://fr-par/proj-uuid/rds_postgres_foo" {
+	if loc != "scaleway://fr-par/proj-uuid/rds/postgres/foo" {
 		t.Errorf("locator = %q", loc)
+	}
+	for _, s := range fake.secrets {
+		if s.Name != "foo" || s.Path != "/rds/postgres/" {
+			t.Errorf("(name, path) = (%q, %q), want (\"foo\", \"/rds/postgres/\")", s.Name, s.Path)
+		}
 	}
 	if ver != "1" {
 		t.Errorf("version = %q, want 1", ver)
@@ -339,17 +352,86 @@ func TestScalewayBackend_SyncTags_NotFound(t *testing.T) {
 	}
 }
 
-func TestScalewayBackend_NameSanitisation(t *testing.T) {
+func TestScalewayBackend_PathAndNameSplit(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantPath string
+		wantName string
+	}{
+		{"rds/postgres/foo", "/rds/postgres/", "foo"},
+		{"/rds/postgres/foo", "/rds/postgres/", "foo"},
+		{"/rds/postgres/foo/", "/rds/postgres/", "foo"},
+		{"foo", "/", "foo"},
+		{"", "/", ""},
+		{"/", "/", ""},
+		{"a/b", "/a/", "b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			gotPath, gotName := scalewayPathAndName(tc.in)
+			if gotPath != tc.wantPath || gotName != tc.wantName {
+				t.Errorf("scalewayPathAndName(%q) = (%q, %q), want (%q, %q)",
+					tc.in, gotPath, gotName, tc.wantPath, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestScalewayBackend_Create_WritesAtPath(t *testing.T) {
 	fake := newFakeScalewayClient()
 	b := newScalewayTestBackend(fake)
 	if _, _, err := b.Create(context.Background(), "/rds/postgres/myapp/", "", sampleDBSecret(), nil, ""); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	if len(fake.secrets) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(fake.secrets))
+	}
 	for _, s := range fake.secrets {
-		if s.Name != "rds_postgres_myapp" {
-			t.Errorf("sanitised name = %q, want rds_postgres_myapp", s.Name)
+		if s.Name != "myapp" {
+			t.Errorf("name = %q, want myapp", s.Name)
+		}
+		if s.Path != "/rds/postgres/" {
+			t.Errorf("path = %q, want /rds/postgres/", s.Path)
 		}
 	}
+}
+
+func TestScalewayBackend_LegacyReadFallback(t *testing.T) {
+	fake := newFakeScalewayClient()
+	b := newScalewayTestBackend(fake)
+
+	// Seed the fake with a legacy secret (root path, flattened name)
+	// as a pre-path operator release would have written it.
+	legacyName := "rds_postgres_legacy"
+	fake.idCounter++
+	id := "secret-id-legacy"
+	fake.secrets[id] = &smapi.Secret{
+		ID:        id,
+		ProjectID: "proj-uuid",
+		Name:      legacyName,
+		Path:      "/",
+		Region:    scw.RegionFrPar,
+	}
+	fake.versions[id] = [][]byte{mustJSON(t, sampleDBSecret())}
+
+	// Lookup using the path-style logical name should hit the legacy
+	// secret via the read-side fallback.
+	got, err := b.Get(context.Background(), "rds/postgres/legacy")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.DBHost != "pg.example.com" {
+		t.Errorf("DBHost = %q, want pg.example.com", got.DBHost)
+	}
+}
+
+func mustJSON(t *testing.T, s *DatabaseSecret) []byte {
+	t.Helper()
+	b, err := s.ToJSONWithTemplate("")
+	if err != nil {
+		t.Fatalf("ToJSONWithTemplate: %v", err)
+	}
+	return b
 }
 
 func TestScalewayBackend_NewBackend_Validation(t *testing.T) {


### PR DESCRIPTION
## Motivation

The Scaleway backend currently flattens the supplied secret name to satisfy Scaleway Secret Manager's name character set (which disallows `/`):

| Backend  | `spec.secretName: rds/postgres/chemcat` lands at |
|----------|--------------------------------------------------|
| AWS SM   | secret name `rds/postgres/chemcat`               |
| Scaleway | secret name `rds_postgres_chemcat` (root path)   |

This forces ExternalSecret consumers to use backend-specific `remoteRef.key` shapes and makes the two backends visually different in their respective consoles, even though the logical name is the same.

Scaleway Secret Manager has a separate `Path` (folder) attribute on the Secret resource — slashes are perfectly legal as path separators. The operator just wasn't using it.

## Description

Split the supplied `spec.secretName` on the last `/`:

- leading segments → Scaleway `Secret.Path` (folder), e.g. `/rds/postgres/`
- trailing segment → Scaleway `Secret.Name`, e.g. `chemcat`
- single-segment input (no `/`) → path `/`, name as-is
- input is `strings.Trim`-ed of surrounding `/` first, so `/rds/postgres/foo/` and `rds/postgres/foo` both produce `(/rds/postgres/, foo)`

Both backends now land at the same logical location for the default `rds/<engine>/<dbName>` shape:

| Backend  | Folder           | Name      |
|----------|------------------|-----------|
| AWS SM   | n/a (flat)       | `rds/postgres/chemcat` |
| Scaleway | `/rds/postgres/` | `chemcat` |

Touched:
- `internal/secrets/scaleway.go` — new `scalewayPathAndName` helper; `findSecret`, `Create`, and `locator` use it; legacy flat-name fallback retained in `findSecret` only.
- `internal/secrets/scaleway_test.go` — fake client now models `Path`; new tests for the split helper, path-aware Create, and legacy-read fallback; updated existing assertions on locator + stored name.

### Backwards compatibility

`findSecret` falls back to the legacy flattened name at root path when the path-style lookup misses, so existing Scaleway secrets written by pre-path operator releases (`rds_postgres_chemcat` at `/`) remain reachable across upgrade. The fallback only fires when the input contained at least one `/` (i.e. the legacy form genuinely differs from the new name); single-segment inputs never trigger it.

New writes always use the path-aware shape — there is no automatic in-place migration of existing legacy secrets. If you want to migrate, delete the legacy secret and re-reconcile the `Database` CR.

## Testing

- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go test ./internal/secrets/... -run Scaleway -v` — 14 Scaleway-backend test cases all green, including:
  - `TestScalewayBackend_PathAndNameSplit` (7 sub-cases covering leading/trailing slashes, single-segment, empty input)
  - `TestScalewayBackend_Create_WritesAtPath`
  - `TestScalewayBackend_LegacyReadFallback`
  - Existing Create/Update/Get/Delete/Tag tests updated to assert new (path, name) shape.

## Migration note for operators

If you're already running this operator against Scaleway and have secrets in production, the new release will leave existing legacy secrets in place (read-side fallback keeps them findable) but new `Database` CRs will write at the path-style location. To unify cleanly:

```bash
# Find legacy secrets (root path, underscore names)
scw secret secret list project-id=<uuid> path=/ | grep '_'

# Delete + re-reconcile the corresponding Database CR to land at the new path
kubectl delete database <name> -n <ns>   # if retainOnDelete: true, the DB row + user stay
kubectl apply -f <database-cr>.yaml
```