### PR TITLE
fix(scaleway): canonicalize Secret.Path to drop trailing slash

### DIFF
--- a/internal/secrets/scaleway.go
+++ b/internal/secrets/scaleway.go
@@ -125,11 +125,11 @@ func parseScalewayRegion(region string) (scw.Region, error) {
 // path `/`. Scaleway accepts [A-Za-z0-9-_.] in names and arbitrary
 // `/`-separated folder paths.
 //
-//	"rds/postgres/foo"   -> ("/rds/postgres/", "foo")
-//	"/rds/postgres/foo"  -> ("/rds/postgres/", "foo")
-//	"/rds/postgres/foo/" -> ("/rds/postgres/", "foo")
-//	"foo"                -> ("/",              "foo")
-//	""                   -> ("/",              "")
+//	"rds/postgres/foo"   -> ("/rds/postgres", "foo")
+//	"/rds/postgres/foo"  -> ("/rds/postgres", "foo")
+//	"/rds/postgres/foo/" -> ("/rds/postgres", "foo")
+//	"foo"                -> ("/",             "foo")
+//	""                   -> ("/",             "")
 func scalewayPathAndName(input string) (string, string) {
 	trimmed := strings.Trim(input, "/")
 	if trimmed == "" {

--- a/internal/secrets/scaleway.go
+++ b/internal/secrets/scaleway.go
@@ -139,7 +139,7 @@ func scalewayPathAndName(input string) (string, string) {
 	if idx < 0 {
 		return "/", trimmed
 	}
-	return "/" + trimmed[:idx] + "/", trimmed[idx+1:]
+	return "/" + trimmed[:idx], trimmed[idx+1:]
 }
 
 // scalewayLegacyName reproduces the pre-path sanitisation (slashes
@@ -156,7 +156,12 @@ func scalewayLegacyName(name string) string {
 // independent of the secret's UUID at lookup time.
 func (b *ScalewayBackend) locator(name string) string {
 	path, n := scalewayPathAndName(name)
-	return fmt.Sprintf("scaleway://%s/%s%s%s", b.region, b.projectID, path, n)
+	sep := "/"
+	if path == "/" {
+		// Root path already supplies the separator — avoid `//<name>`.
+		sep = ""
+	}
+	return fmt.Sprintf("scaleway://%s/%s%s%s%s", b.region, b.projectID, path, sep, n)
 }
 
 // findSecret looks up a Scaleway Secret by (Path, Name, project).

--- a/internal/secrets/scaleway_test.go
+++ b/internal/secrets/scaleway_test.go
@@ -194,8 +194,8 @@ func TestScalewayBackend_Create_NewSecret(t *testing.T) {
 		t.Errorf("locator = %q", loc)
 	}
 	for _, s := range fake.secrets {
-		if s.Name != "foo" || s.Path != "/rds/postgres/" {
-			t.Errorf("(name, path) = (%q, %q), want (\"foo\", \"/rds/postgres/\")", s.Name, s.Path)
+		if s.Name != "foo" || s.Path != "/rds/postgres" {
+			t.Errorf("(name, path) = (%q, %q), want (\"foo\", \"/rds/postgres\")", s.Name, s.Path)
 		}
 	}
 	if ver != "1" {
@@ -358,13 +358,13 @@ func TestScalewayBackend_PathAndNameSplit(t *testing.T) {
 		wantPath string
 		wantName string
 	}{
-		{"rds/postgres/foo", "/rds/postgres/", "foo"},
-		{"/rds/postgres/foo", "/rds/postgres/", "foo"},
-		{"/rds/postgres/foo/", "/rds/postgres/", "foo"},
+		{"rds/postgres/foo", "/rds/postgres", "foo"},
+		{"/rds/postgres/foo", "/rds/postgres", "foo"},
+		{"/rds/postgres/foo/", "/rds/postgres", "foo"},
 		{"foo", "/", "foo"},
 		{"", "/", ""},
 		{"/", "/", ""},
-		{"a/b", "/a/", "b"},
+		{"a/b", "/a", "b"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
@@ -390,9 +390,42 @@ func TestScalewayBackend_Create_WritesAtPath(t *testing.T) {
 		if s.Name != "myapp" {
 			t.Errorf("name = %q, want myapp", s.Name)
 		}
-		if s.Path != "/rds/postgres/" {
-			t.Errorf("path = %q, want /rds/postgres/", s.Path)
+		if s.Path != "/rds/postgres" {
+			t.Errorf("path = %q, want /rds/postgres", s.Path)
 		}
+	}
+}
+
+// Regression: on a second reconcile the existence check has to find
+// the Secret the operator wrote on the first reconcile, otherwise the
+// operator loops forever attempting CreateSecret and Scaleway returns
+// "name is wrongly formatted, cannot have same secret name in same
+// path". Pre-fix the path-and-name split produced "/rds/postgres/"
+// (trailing slash) for both the Create request and the subsequent
+// find filter; Scaleway normalised the stored Path to "/rds/postgres"
+// and the in-code `s.Path == path` comparison rejected the hit.
+func TestScalewayBackend_FindAfterCreate(t *testing.T) {
+	fake := newFakeScalewayClient()
+	b := newScalewayTestBackend(fake)
+
+	if _, _, err := b.Create(context.Background(), "rds/postgres/chemcat", "", sampleDBSecret(), nil, ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ok, err := b.Exists(context.Background(), "rds/postgres/chemcat")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Exists after Create returned false — operator would loop on CreateSecret")
+	}
+
+	got, err := b.Get(context.Background(), "rds/postgres/chemcat")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.DBHost != "pg.example.com" {
+		t.Errorf("Get returned wrong payload: DBHost = %q", got.DBHost)
 	}
 }
 

--- a/internal/secrets/scaleway_test.go
+++ b/internal/secrets/scaleway_test.go
@@ -79,9 +79,16 @@ func (f *fakeScalewayClient) CreateSecret(req *smapi.CreateSecretRequest, _ ...s
 	if req.Description != nil {
 		desc = *req.Description
 	}
+	// Mirror Scaleway Secret Manager's server-side normalisation:
+	// trailing `/` is stripped from non-root paths. Tests rely on this
+	// to catch the round-trip bug where Create wrote `/rds/postgres/`
+	// but ListSecrets later returned `/rds/postgres`.
 	path := "/"
 	if req.Path != nil {
-		path = *req.Path
+		path = strings.TrimRight(*req.Path, "/")
+		if path == "" {
+			path = "/"
+		}
 	}
 	s := &smapi.Secret{
 		ID:          id,


### PR DESCRIPTION
## Motivation

After v0.4.0 (#170) landed the Scaleway native path/name split, every reconcile **after** a successful first Create looped on `CreateSecret` and Scaleway responded:

```
scaleway create-secret failed: scaleway-sdk-go: invalid argument(s):
  name is wrongly formatted, cannot have same secret name in same path
```

The DatabaseCR therefore stayed in `Phase: Error` on every reconcile after the first, even though the SM secret had been created successfully.

## Root cause

`scalewayPathAndName` returned **`"/rds/postgres/"`** (trailing slash) for input `"rds/postgres/foo"`. Scaleway Secret Manager normalises the stored `Secret.Path` to **`"/rds/postgres"`** (no trailing slash) on create. Two follow-on bugs on the next reconcile:

1. `findSecret` calls `ListSecrets` with `Path: "/rds/postgres/"`. Scaleway's path filter compares against the normalised stored value and returns 0 hits.
2. Even when ListSecrets does return the secret (e.g. when Name alone narrows enough), the in-code `s.Name == n && s.Path == path` rejects the hit because `s.Path` is `"/rds/postgres"` while `path` is `"/rds/postgres/"`.

Either way `findSecret` reported the secret absent, the reconciler fell through to `CreateSecret`, Scaleway rejected the second create — operator stuck.

## Change

- `scalewayPathAndName`: canonicalize non-root paths to drop the trailing slash. Root path stays `"/"`.
- `locator`: insert the path/name separator explicitly when path isn't root, otherwise the URI becomes `scaleway://region/project/rds/postgresfoo` (missing `/`).
- Updated existing `TestScalewayBackend_PathAndNameSplit` + `TestScalewayBackend_Create_WritesAtPath` + `TestScalewayBackend_Create_NewSecret` expectations.
- Added `TestScalewayBackend_FindAfterCreate` regression test that drives the round-trip (`Create` → `Exists` → `Get`) and fails before the fix.

## Verified

```
$ go test ./internal/secrets/ -run TestScaleway -v
=== RUN   TestScalewayBackend_Create_NewSecret
--- PASS: TestScalewayBackend_Create_NewSecret (0.00s)
…
=== RUN   TestScalewayBackend_FindAfterCreate
--- PASS: TestScalewayBackend_FindAfterCreate (0.00s)
=== RUN   TestScalewayBackend_LegacyReadFallback
--- PASS: TestScalewayBackend_LegacyReadFallback (0.00s)
PASS
```

## Real-world repro

On a staging Scaleway Kapsule cluster running v0.4.0 the operator log loops the following on every reconcile of an existing Database CR:

```
INFO  Checked resource existence  secretExists=false  secretName=rds/postgres/chemcat
INFO  Secret missing for existing user/database — rotating password and recreating secret
INFO  Creating new secret in backend  secretName=rds/postgres/chemcat
ERROR Reconciler error  error="scaleway create-secret failed: scaleway-sdk-go: invalid argument(s): name is wrongly formatted, cannot have same secret name in same path"
```

After applying this fix the second reconcile takes the `Resources already exist and spec unchanged, skipping reconciliation` path.
