### PR TITLE
feat: default Scaleway secret name to rdb/<engine>/<databaseName>

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -63,10 +63,10 @@ matches the chosen backend's native service name:
 
 | Backend     | Default `secretName`                  |
 | ----------- | ------------------------------------- |
-| AWS         | `rds/<engine>/<databaseName>`         |
-| Scaleway    | `rdb/<engine>/<databaseName>`         |
-| Infisical   | `rds/<engine>/<databaseName>`         |
-| Kubernetes  | `rds-<engine>-<databaseName>` (DNS-1123) |
+| AWS         | `rds/<engine>/<databaseName>` (AWS service name) |
+| Scaleway    | `rdb/<engine>/<databaseName>` (Scaleway service name) |
+| Infisical   | `db/<engine>/<databaseName>` (backend-neutral) |
+| Kubernetes  | `db-<engine>-<databaseName>` (backend-neutral; DNS-1123) |
 
 ### connectionString.kubernetes
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -53,10 +53,20 @@ This creates:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `username` | string | `databaseName` | Username for created user |
-| `secretName` | string | `rds/<engine>/<databaseName>` | AWS secret path |
+| `secretName` | string | backend-specific (see below) | Secret name in the chosen backend |
 | `privileges` | []string | `["ALL"]` | Privileges to grant |
 | `retainOnDelete` | bool | `true` | Retain resources on CR deletion |
 | `secretBackend.aws` | object | - | AWS Secrets Manager config |
+
+When `secretName` is omitted the operator generates a default that
+matches the chosen backend's native service name:
+
+| Backend     | Default `secretName`                  |
+| ----------- | ------------------------------------- |
+| AWS         | `rds/<engine>/<databaseName>`         |
+| Scaleway    | `rdb/<engine>/<databaseName>`         |
+| Infisical   | `rds/<engine>/<databaseName>`         |
+| Kubernetes  | `rds-<engine>-<databaseName>` (DNS-1123) |
 
 ### connectionString.kubernetes
 

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -1126,19 +1126,27 @@ func needsReconciliation(db *databasev1alpha1.Database) bool {
 }
 
 // getSecretNameOrDefault returns the secret name from the spec, or generates a backend-aware default.
-// AWS / Infisical: rds/<engine>/<databaseName> (path-shaped names allowed; AWS RDS is the service name).
-// Scaleway: rdb/<engine>/<databaseName> (path-shaped names allowed; Scaleway RDB is the service name).
-// Kubernetes: rds-<engine>-<databaseName> (DNS-1123 — '/' is rejected by Secret name validation).
+// AWS:        rds/<engine>/<databaseName> (path-shaped; AWS RDS is the service name).
+// Scaleway:   rdb/<engine>/<databaseName> (path-shaped; Scaleway RDB is the service name).
+// Infisical:  db/<engine>/<databaseName>  (path-shaped; backend-neutral, hosted secret store).
+// Kubernetes: db-<engine>-<databaseName>  (DNS-1123 — '/' is rejected by Secret name validation).
 func getSecretNameOrDefault(db *databasev1alpha1.Database) string {
 	if db.Spec.SecretName != "" {
 		return db.Spec.SecretName
 	}
+	// Default prefix uses the cloud's own service name for AWS+Scaleway
+	// (matches what Terraform / Cloud Console operators already write
+	// for shared admin DSNs in the same namespace) and a neutral `db`
+	// for non-cloud backends.
 	prefix := "rds"
 	sep := "/"
 	switch {
 	case db.Spec.SecretBackend.Scaleway != nil:
 		prefix = "rdb"
+	case db.Spec.SecretBackend.Infisical != nil:
+		prefix = "db"
 	case db.Spec.SecretBackend.Kubernetes != nil:
+		prefix = "db"
 		sep = "-"
 	}
 	return fmt.Sprintf("%s%s%s%s%s", prefix, sep, db.Spec.Engine, sep, db.Spec.DatabaseName)

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -1126,17 +1126,22 @@ func needsReconciliation(db *databasev1alpha1.Database) bool {
 }
 
 // getSecretNameOrDefault returns the secret name from the spec, or generates a backend-aware default.
-// AWS / Infisical: rds/<engine>/<databaseName> (path-shaped names allowed).
+// AWS / Infisical: rds/<engine>/<databaseName> (path-shaped names allowed; AWS RDS is the service name).
+// Scaleway: rdb/<engine>/<databaseName> (path-shaped names allowed; Scaleway RDB is the service name).
 // Kubernetes: rds-<engine>-<databaseName> (DNS-1123 — '/' is rejected by Secret name validation).
 func getSecretNameOrDefault(db *databasev1alpha1.Database) string {
 	if db.Spec.SecretName != "" {
 		return db.Spec.SecretName
 	}
+	prefix := "rds"
 	sep := "/"
-	if db.Spec.SecretBackend.Kubernetes != nil {
+	switch {
+	case db.Spec.SecretBackend.Scaleway != nil:
+		prefix = "rdb"
+	case db.Spec.SecretBackend.Kubernetes != nil:
 		sep = "-"
 	}
-	return fmt.Sprintf("rds%s%s%s%s", sep, db.Spec.Engine, sep, db.Spec.DatabaseName)
+	return fmt.Sprintf("%s%s%s%s%s", prefix, sep, db.Spec.Engine, sep, db.Spec.DatabaseName)
 }
 
 // getRegion determines the AWS region from the Database spec.

--- a/internal/controller/database_controller_unit_test.go
+++ b/internal/controller/database_controller_unit_test.go
@@ -564,7 +564,20 @@ func TestGetSecretNameOrDefault(t *testing.T) {
 			want: "rdb/postgres/billing",
 		},
 		{
-			name: "Kubernetes backend - DNS-1123 safe rds-<engine>-<database>",
+			name: "Infisical backend - backend-neutral db/<engine>/<database>",
+			db: &databasev1alpha1.Database{
+				Spec: databasev1alpha1.DatabaseSpec{
+					Engine:       databasev1alpha1.DatabaseEnginePostgres,
+					DatabaseName: "fulfillment",
+					SecretBackend: databasev1alpha1.SecretBackend{
+						Infisical: &databasev1alpha1.InfisicalSecretBackend{},
+					},
+				},
+			},
+			want: "db/postgres/fulfillment",
+		},
+		{
+			name: "Kubernetes backend - DNS-1123 safe db-<engine>-<database>",
 			db: &databasev1alpha1.Database{
 				Spec: databasev1alpha1.DatabaseSpec{
 					Engine:       databasev1alpha1.DatabaseEnginePostgres,
@@ -574,7 +587,7 @@ func TestGetSecretNameOrDefault(t *testing.T) {
 					},
 				},
 			},
-			want: "rds-postgres-loyalty",
+			want: "db-postgres-loyalty",
 		},
 	}
 

--- a/internal/controller/database_controller_unit_test.go
+++ b/internal/controller/database_controller_unit_test.go
@@ -547,6 +547,35 @@ func TestGetSecretNameOrDefault(t *testing.T) {
 			},
 			want: "rds/postgres/testdb",
 		},
+		{
+			name: "Scaleway backend - uses rdb/<engine>/<database> (Scaleway's service name)",
+			db: &databasev1alpha1.Database{
+				Spec: databasev1alpha1.DatabaseSpec{
+					Engine:       databasev1alpha1.DatabaseEnginePostgres,
+					DatabaseName: "billing",
+					SecretBackend: databasev1alpha1.SecretBackend{
+						Scaleway: &databasev1alpha1.ScalewaySecretBackend{
+							Region:    "fr-par",
+							ProjectID: "00000000-0000-0000-0000-000000000000",
+						},
+					},
+				},
+			},
+			want: "rdb/postgres/billing",
+		},
+		{
+			name: "Kubernetes backend - DNS-1123 safe rds-<engine>-<database>",
+			db: &databasev1alpha1.Database{
+				Spec: databasev1alpha1.DatabaseSpec{
+					Engine:       databasev1alpha1.DatabaseEnginePostgres,
+					DatabaseName: "loyalty",
+					SecretBackend: databasev1alpha1.SecretBackend{
+						Kubernetes: &databasev1alpha1.KubernetesSecretBackend{},
+					},
+				},
+			},
+			want: "rds-postgres-loyalty",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation

The default secret name format `rds/<engine>/<databaseName>` was leaking AWS terminology into every backend, including Scaleway (whose service is called RDB), Infisical (a backend-neutral hosted secret store), and Kubernetes (a Secret resource). Cluster operators on Scaleway also use `/rdb/postgres/<instance>` for their own Terraform-written admin DSNs, so the operator's secrets sat awkwardly under a different naming convention in the same Secret Manager namespace.

## Description

`getSecretNameOrDefault` now picks a backend-appropriate prefix:

| Backend     | Default `secretName`                  | Origin                                  |
| ----------- | ------------------------------------- | --------------------------------------- |
| AWS         | `rds/<engine>/<databaseName>`         | AWS service name (unchanged)            |
| **Scaleway**    | **`rdb/<engine>/<databaseName>`**         | Scaleway service name (new)             |
| **Infisical**   | **`db/<engine>/<databaseName>`**          | backend-neutral (new)                   |
| **Kubernetes**  | **`db-<engine>-<databaseName>`** (DNS-1123) | backend-neutral (new)                   |

Per-CR `spec.secretName` continues to win over the default for every backend.

`docs/USAGE.md` updated with the per-backend default table.

## Breaking change (Scaleway, Infisical, Kubernetes)

Three of the four backends get a new default secret name. Existing users relying on the default will see the operator create a new secret at the new path on next reconcile while the old `rds*` secret becomes orphan (still in the store, no longer written). Two migration paths:

1. **No-op via override** — set `spec.secretName: rds/<engine>/<dbname>` (or `rds-<engine>-<dbname>` for Kubernetes) on each Database CR to preserve the old path.
2. **Adopt the new default** — update consuming ExternalSecrets / scripts to read from the new path, then delete the orphan secret.

AWS users are unaffected.

## Testing

- `go test ./...` ✓ — new test cases for Scaleway, Infisical, and Kubernetes branches of `TestGetSecretNameOrDefault` pass.
- Build + unit tests green locally.
- AWS branch still produces `rds/postgres/<db>` (preserved test case).

Refs: opzkit#175 (env-auth fallback that made Scaleway production-viable in the first place)