### PR TITLE
feat(scaleway): auto-detect operator default projectID/region from instance metadata

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 
 	databasev1alpha1 "opzkit/database-user-operator/api/v1alpha1"
 	"opzkit/database-user-operator/internal/controller"
+	"opzkit/database-user-operator/internal/secrets"
 )
 
 var (
@@ -53,6 +54,11 @@ func main() {
 		"version", version,
 		"gitCommit", gitCommit,
 		"buildDate", buildDate)
+
+	// Auto-detect Scaleway operator defaults from instance metadata when
+	// SCW_DEFAULT_PROJECT_ID / SCW_DEFAULT_REGION aren't explicitly set.
+	// Best-effort and non-fatal: a no-op off Scaleway.
+	secrets.ApplyScalewayMetadataDefaults(context.Background(), setupLog)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.8
 	github.com/aws/aws-sdk-go-v2/config v1.32.19
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.8
+	github.com/go-logr/logr v1.4.3
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/infisical/go-sdk v0.7.2
 	github.com/lib/pq v1.12.3
@@ -48,7 +49,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect

--- a/internal/secrets/scaleway_metadata.go
+++ b/internal/secrets/scaleway_metadata.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 OpzKit
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+*/
+
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// Scaleway exposes per-instance metadata over a link-local HTTP endpoint
+// reachable from the node (and from pods sharing the node network). We
+// query it to auto-derive the operator's home Project and region so a
+// Scaleway-hosted operator needs no explicit SCW_DEFAULT_* configuration.
+const (
+	scalewayMetadataURL     = "http://169.254.42.42"
+	scalewayMetadataTimeout = 2 * time.Second
+	scalewayMetadataMaxBody = 1 << 20 // 1 MiB cap on the metadata response
+)
+
+// scalewayInstanceMetadata is the subset of the /conf payload we read.
+// Scaleway returns far more; json.Unmarshal ignores the rest.
+type scalewayInstanceMetadata struct {
+	Project  string `json:"project"`
+	Location struct {
+		ZoneID string `json:"zone_id"`
+	} `json:"location"`
+}
+
+// fetchScalewayInstanceMetadata GETs /conf?format=json from baseURL and
+// decodes the Project + zone. It uses the supplied client (which must
+// carry its own timeout) and a context deadline — it never mutates
+// http.DefaultClient, unlike the Scaleway SDK's metadata helper.
+func fetchScalewayInstanceMetadata(ctx context.Context, httpClient *http.Client, baseURL string) (*scalewayInstanceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/conf?format=json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("scaleway metadata: build request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scaleway metadata: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scaleway metadata: unexpected status %d", resp.StatusCode)
+	}
+
+	var meta scalewayInstanceMetadata
+	if err := json.NewDecoder(io.LimitReader(resp.Body, scalewayMetadataMaxBody)).Decode(&meta); err != nil {
+		return nil, fmt.Errorf("scaleway metadata: decode response: %w", err)
+	}
+	return &meta, nil
+}
+
+// scalewaySecretManagerRegions is the set of regions Scaleway Secret
+// Manager supports — mirrors the CRD region enum. scw.ParseRegion only
+// validates the format (it accepts any well-formed "xx-yyy"), so we
+// gate metadata-derived regions on membership here.
+var scalewaySecretManagerRegions = map[string]struct{}{
+	"fr-par": {},
+	"nl-ams": {},
+	"pl-waw": {},
+}
+
+// zoneToRegion derives a region from a Scaleway zone id (e.g. fr-par-1 ->
+// fr-par) and validates it against the supported region set.
+func zoneToRegion(zoneID string) (string, error) {
+	parts := strings.Split(zoneID, "-")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("scaleway metadata: cannot derive region from zone %q", zoneID)
+	}
+	region := parts[0] + "-" + parts[1]
+	if _, ok := scalewaySecretManagerRegions[region]; !ok {
+		return "", fmt.Errorf("scaleway metadata: region %q derived from zone %q is not a supported Secret Manager region", region, zoneID)
+	}
+	return region, nil
+}
+
+// ApplyScalewayMetadataDefaults best-effort populates the
+// SCW_DEFAULT_PROJECT_ID / SCW_DEFAULT_REGION env vars from the node's
+// Scaleway instance metadata, but only for vars that aren't already set.
+//
+// Precedence is preserved: an explicitly configured operator env var
+// always wins over metadata. Combined with per-CR spec fields the full
+// order is CR field -> operator env -> metadata-derived env -> error.
+//
+// It is intentionally non-fatal: when metadata is unreachable (the
+// operator isn't on Scaleway, or a CNI blocks the link-local address)
+// it logs at V(1) and returns, leaving resolution to fall through to the
+// existing error path.
+func ApplyScalewayMetadataDefaults(ctx context.Context, logger logr.Logger) {
+	needProject := os.Getenv(ScalewayEnvDefaultProjectID) == ""
+	needRegion := os.Getenv(ScalewayEnvDefaultRegion) == ""
+	if !needProject && !needRegion {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, scalewayMetadataTimeout)
+	defer cancel()
+
+	meta, err := fetchScalewayInstanceMetadata(ctx, &http.Client{Timeout: scalewayMetadataTimeout}, scalewayMetadataURL)
+	if err != nil {
+		logger.V(1).Info("Scaleway instance metadata unavailable; skipping operator-default auto-detection", "error", err.Error())
+		return
+	}
+
+	if needProject {
+		if meta.Project == "" {
+			logger.V(1).Info("Scaleway instance metadata returned no project; leaving SCW_DEFAULT_PROJECT_ID unset")
+		} else {
+			_ = os.Setenv(ScalewayEnvDefaultProjectID, meta.Project)
+			logger.Info("Derived Scaleway default projectID from instance metadata", "projectID", meta.Project)
+		}
+	}
+
+	if needRegion {
+		region, err := zoneToRegion(meta.Location.ZoneID)
+		if err != nil {
+			logger.V(1).Info("Could not derive Scaleway default region from instance metadata", "zoneID", meta.Location.ZoneID, "error", err.Error())
+		} else {
+			_ = os.Setenv(ScalewayEnvDefaultRegion, region)
+			logger.Info("Derived Scaleway default region from instance metadata", "region", region, "zoneID", meta.Location.ZoneID)
+		}
+	}
+}

--- a/internal/secrets/scaleway_metadata_test.go
+++ b/internal/secrets/scaleway_metadata_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 OpzKit
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+*/
+
+package secrets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchScalewayInstanceMetadata(t *testing.T) {
+	const body = `{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"project": "5a339eb9-920f-4256-bbf2-d9ae6e0fb676",
+		"location": {"zone_id": "fr-par-1", "node_id": "x"},
+		"tags": ["ignored"]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/conf" || r.URL.Query().Get("format") != "json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	meta, err := fetchScalewayInstanceMetadata(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchScalewayInstanceMetadata: %v", err)
+	}
+	if meta.Project != "5a339eb9-920f-4256-bbf2-d9ae6e0fb676" {
+		t.Errorf("Project = %q, want 5a339eb9-920f-4256-bbf2-d9ae6e0fb676", meta.Project)
+	}
+	if meta.Location.ZoneID != "fr-par-1" {
+		t.Errorf("ZoneID = %q, want fr-par-1", meta.Location.ZoneID)
+	}
+}
+
+func TestFetchScalewayInstanceMetadata_NotOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchScalewayInstanceMetadata(context.Background(), srv.Client(), srv.URL); err == nil {
+		t.Fatal("fetchScalewayInstanceMetadata: want error on non-200, got nil")
+	}
+}
+
+func TestZoneToRegion(t *testing.T) {
+	tests := []struct {
+		zone    string
+		want    string
+		wantErr bool
+	}{
+		{zone: "fr-par-1", want: "fr-par"},
+		{zone: "fr-par-2", want: "fr-par"},
+		{zone: "nl-ams-1", want: "nl-ams"},
+		{zone: "pl-waw-3", want: "pl-waw"},
+		{zone: "us-east-1", wantErr: true}, // not a supported Scaleway region
+		{zone: "frpar", wantErr: true},
+		{zone: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.zone, func(t *testing.T) {
+			got, err := zoneToRegion(tt.zone)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("zoneToRegion(%q): want error, got %q", tt.zone, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("zoneToRegion(%q): unexpected error: %v", tt.zone, err)
+			}
+			if got != tt.want {
+				t.Errorf("zoneToRegion(%q) = %q, want %q", tt.zone, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

At startup the operator queries the Scaleway instance metadata endpoint (`http://169.254.42.42/conf?format=json`) and, for any of `SCW_DEFAULT_PROJECT_ID` / `SCW_DEFAULT_REGION` **not already set**, populates it from the node's `project` and `location.zone_id` (zone `fr-par-1` → region `fr-par`).

A Scaleway-hosted operator then needs zero default config: it discovers its home Project and region from the node it runs on.

## Resolution order

This is the third tier of the operator-default chain introduced in #188:

```
CR spec field  →  operator env (explicit)  →  metadata-derived env  →  error
```

Explicit operator env always wins over metadata (metadata only fills *unset* vars).

## Behaviour

- **Best-effort, non-fatal.** Off Scaleway, or behind a CNI that blocks the link-local address, the metadata GET fails; it logs at `V(1)` and leaves the env vars unset so resolution falls through to the normal error path.
- **Region gated** on the supported Secret Manager set (`fr-par`, `nl-ams`, `pl-waw`) — `scw.ParseRegion` only checks format, so membership is enforced explicitly.
- Uses a dedicated `http.Client` with its own 2s timeout + context deadline. Deliberately **not** the Scaleway SDK metadata helper, which mutates `http.DefaultClient.Timeout` as a global side effect.

## Changes

- `internal/secrets/scaleway_metadata.go` — metadata fetch, `zoneToRegion`, `ApplyScalewayMetadataDefaults`.
- `cmd/manager/main.go` — call detection once at startup, before manager creation.
- `internal/secrets/scaleway_metadata_test.go` — httptest-backed fetch tests + `zoneToRegion` table tests.
- `go.mod` — promote `github.com/go-logr/logr` to a direct dependency.

## Dependency note

Stacked conceptually on #188 (which makes the CR fields optional and adds the env resolvers that read `SCW_DEFAULT_*`). This branch is cut from `main` and is self-contained (it defines local copies of the env-var names), so it builds standalone. **Merge #188 first, then rebase this on main** — the env-var name constants can then be de-duplicated against #188's exported versions.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/secrets/...` (fetch + zoneToRegion)
- [ ] Deploy on a Scaleway Kapsule cluster with no `SCW_DEFAULT_*` set; confirm startup logs "Derived Scaleway default projectID/region from instance metadata" and a CR omitting the fields resolves.
- [ ] Confirm link-local reachability from the operator pod under the cluster's CNI.