### PR TITLE
fix(helm): set metadata.namespace on all namespaced resources

### DIFF
--- a/helm/database-user-operator/templates/deployment.yaml
+++ b/helm/database-user-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "database-user-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "database-user-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/database-user-operator/templates/service.yaml
+++ b/helm/database-user-operator/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "database-user-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "database-user-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/database-user-operator/templates/serviceaccount.yaml
+++ b/helm/database-user-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "database-user-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "database-user-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/database-user-operator/templates/servicemonitor.yaml
+++ b/helm/database-user-operator/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "database-user-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "database-user-operator.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
## Problem

The chart never writes `metadata.namespace` on four resources:

- `templates/serviceaccount.yaml`
- `templates/service.yaml` (metrics Service)
- `templates/deployment.yaml`
- `templates/servicemonitor.yaml`

`templates/rbac.yaml` is the exception — it templates `{{ .Release.Namespace }}` on the Role, the RoleBinding and `subjects[].namespace` in all three bindings.

This is invisible under `helm install -n <ns>`: the client supplies the namespace at apply time, so a resource with no `metadata.namespace` lands in the release namespace. It has always worked.

It breaks when the chart is rendered with `helm template` and applied by something else — the usual GitOps path, and what kustomize does when it inflates the chart through `helmCharts:`. There, `helmCharts[].namespace` only feeds `.Release.Namespace` for templating; it does not inject `metadata.namespace`. The four resources come out namespace-less, while the RBAC that does template it applies fine.

Argo CD rejects the result:

```
Namespace for db-operator /v1, Kind=ServiceAccount is missing.
Namespace for db-operator apps/v1, Kind=Deployment is missing.
Namespace for db-operator-metrics /v1, Kind=Service is missing.
```

kustomize used to paper over this — up to 5.7.x its namespace transformer *created* the field on Helm-inflated resources. 5.8.0 only rewrites a field that already exists, so the gap surfaced. Argo CD v3.3.0 builds ship 5.8.0.

## Change

`namespace: {{ .Release.Namespace }}` on those four resources. No values changes, no version-gated logic. `rbac.yaml` needs nothing.

## Compatibility

Rendering under `helm install` is unchanged — `.Release.Namespace` *is* the `-n` value, so this makes explicit what Helm was already doing implicitly. The only pattern it would break is render-once-apply-to-many-namespaces, which a namespaced operator release does not support anyway.

## Verification

```
helm template db-operator ./helm/database-user-operator -n db-operator \
  --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true
```

Every namespaced resource now carries `namespace: db-operator`; only the three ClusterRoles and two ClusterRoleBindings render without one, as they should.

`ServiceMonitor` is included even though it is gated behind `metrics.serviceMonitor.enabled` — it has the same defect, so enabling it on a GitOps-rendered install would hit the same wall.